### PR TITLE
✨ added complimentary color for hex codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ console.log(Random.complimentaryColor("rgb(100,200,250)"));
 
 console.log(Random.complimentaryColor("hsl(120,50%,50%)"));
 // returns - hsl(300,50.00%,50.00%)
+
+console.log(Random.complimentaryColor("#ffffff"));
+// returns - #000000
 ```
 
 ### `randomShade`: Generate a random shade (darker version) of a given color.

--- a/index.js
+++ b/index.js
@@ -372,6 +372,8 @@ const Random = {
 
 		// Convert input color to HSL
 		let hslColor;
+
+		// conditions to return the same type of color format as in input
 		if (color.startsWith("#")) {
 			return complimentaryHex(color);
 		}
@@ -386,7 +388,7 @@ const Random = {
 			);
 		}
 
-		// Calculate complementary hue
+		// complementary hue calculation
 		let complementaryHue = (hslColor[0] + 180) % 360;
 
 		// Convert complementary hue back to original format

--- a/index.js
+++ b/index.js
@@ -354,16 +354,35 @@ const Random = {
 			return Math.min(Math.max(value, min), max);
 		};
 
+		const complimentaryHex = function(hex) {
+			if (!/^#[0-9A-F]{6}$/i.test(hex)) {
+				throw new Error("Unsupported color format. Only RGB, HSL and HEX formats are supported.");
+			}
+			hex = hex.substring(1);
+			let r = parseInt(hex.substring(0, 2), 16);
+			let g = parseInt(hex.substring(2, 4), 16);
+			let b = parseInt(hex.substring(4, 6), 16);
+	
+			r = (255 - r).toString(16).padStart(2, '0');
+			g = (255 - g).toString(16).padStart(2, '0');
+			b = (255 - b).toString(16).padStart(2, '0');
+	
+			return `#${r}${g}${b}`;
+		}
+
 		// Convert input color to HSL
 		let hslColor;
-		if (color.startsWith("rgb")) {
+		if (color.startsWith("#")) {
+			return complimentaryHex(color);
+		}
+		else if (color.startsWith("rgb")) {
 			const [r, g, b] = color.match(/\d+/g);
 			hslColor = rgbToHsl(parseInt(r), parseInt(g), parseInt(b));
 		} else if (color.startsWith("hsl")) {
 			hslColor = color.match(/\d+/g).map(Number);
 		} else {
 			throw new Error(
-				"Unsupported color format. Only RGB and HSL formats are supported."
+				"Unsupported color format. Only RGB, HSL and HEX formats are supported."
 			);
 		}
 
@@ -739,5 +758,6 @@ const Random = {
 		return true;
 	},
 };
+
 
 module.exports = Random;


### PR DESCRIPTION
Implemented the complimentary color for hex codes in the complimentaryColor function.

![image](https://github.com/AnshSinghSonkhia/random-math/assets/118462299/6483edb2-0c2d-4eb0-b69d-339bd1783b10)

These are a few tests for the function.